### PR TITLE
Add Support for Publish-Subscribe (Pub-Sub) Communication Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,41 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.wfa</groupId>
+        <artifactId>wfa-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cross-talk</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>CrossTalk</name>
+        <description>A flexible middleware enabling seamless communication between distributed applications via Pub-Sub, Message Queues, Request Response etc.</description>
+
+    <properties>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>3.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-transforms</artifactId>
+            <version>3.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.3</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/com/wfa/crosstalk/config/AutoConfig.java
+++ b/src/main/java/com/wfa/crosstalk/config/AutoConfig.java
@@ -1,0 +1,8 @@
+package com.wfa.crosstalk.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AutoConfig {
+
+}

--- a/src/main/java/com/wfa/crosstalk/config/Properties.java
+++ b/src/main/java/com/wfa/crosstalk/config/Properties.java
@@ -1,0 +1,5 @@
+package com.wfa.crosstalk.config;
+
+public class Properties {
+
+}

--- a/src/main/java/com/wfa/crosstalk/core/model/StandardMessage.java
+++ b/src/main/java/com/wfa/crosstalk/core/model/StandardMessage.java
@@ -1,0 +1,34 @@
+package com.wfa.crosstalk.core.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public class StandardMessage implements Serializable{
+    private final String messageId;
+    private final long timestamp;
+    private final String message;
+
+    public StandardMessage() {
+        this.messageId = UUID.randomUUID().toString(); // Auto-generate unique messageId
+        this.timestamp = System.currentTimeMillis();
+        this.message = "StandardMessage";
+    }
+
+    public StandardMessage(String message) {
+        this.messageId = UUID.randomUUID().toString(); // Auto-generate unique messageId
+        this.timestamp = System.currentTimeMillis();
+        this.message = message;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/wfa/crosstalk/core/pubsub/Publisher.java
+++ b/src/main/java/com/wfa/crosstalk/core/pubsub/Publisher.java
@@ -1,0 +1,5 @@
+package com.wfa.crosstalk.core.pubsub;
+
+public interface Publisher {
+    void publish(String topic, Object message);
+}

--- a/src/main/java/com/wfa/crosstalk/core/pubsub/Subscriber.java
+++ b/src/main/java/com/wfa/crosstalk/core/pubsub/Subscriber.java
@@ -1,0 +1,7 @@
+package com.wfa.crosstalk.core.pubsub;
+
+import java.util.function.Consumer;
+
+public interface Subscriber {
+    <T> void subscribe(String topic, Class<T> targetType, Consumer<T> messageHandler);
+}

--- a/src/main/java/com/wfa/crosstalk/core/pubsub/TopicManager.java
+++ b/src/main/java/com/wfa/crosstalk/core/pubsub/TopicManager.java
@@ -1,0 +1,8 @@
+package com.wfa.crosstalk.core.pubsub;
+
+import java.util.List;
+
+public interface TopicManager {
+    void createTopic(String topicName, int partitions, short replicationFactor);
+    List<String> listTopics();
+}

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/PublisherImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/PublisherImpl.java
@@ -29,7 +29,7 @@ public class PublisherImpl implements Publisher {
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         logger.info("Creating Kafka producer with bootstrapServers: {}", bootstrapServers);
-        this.producer = new KafkaProducer<>(properties);    // TODO: Investigate and fix
+        this.producer = new KafkaProducer<>(properties);
         this.objectMapper = new ObjectMapper();
     }
 

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/PublisherImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/PublisherImpl.java
@@ -1,0 +1,58 @@
+package com.wfa.crosstalk.impl.pubsub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wfa.crosstalk.core.pubsub.Publisher;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+import java.util.Properties;
+
+@Service
+public class PublisherImpl implements Publisher {
+
+    private static final Logger logger = LoggerFactory.getLogger(PublisherImpl.class);
+
+    private final KafkaProducer<String, String> producer;
+    private final ObjectMapper objectMapper;
+
+    public PublisherImpl(@Value("${com.wfa.crosstalk.pubsub.bootstrapServers}") String bootstrapServers) {
+        Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        logger.info("Creating Kafka producer with bootstrapServers: {}", bootstrapServers);
+        this.producer = new KafkaProducer<>(properties);    // TODO: Investigate and fix
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public void publish(String topic, Object message) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(message);
+            ProducerRecord<String, String> record = new ProducerRecord<>(topic, messageJson);
+            producer.send(record, (metadata, exception) -> {
+                if (exception != null) {
+                    logger.error("Error while publishing message to Kafka: {}", exception.getMessage(), exception);
+                } else {
+                    logger.debug("Message successfully sent to topic {} with offset {}", topic, metadata.offset());
+                }
+            });
+        } catch (Exception e) {
+            logger.error("Error serializing message: {}", e.getMessage(), e);
+        }
+    }
+
+    @PreDestroy
+    public void close() {
+        logger.info("Closing Kafka producer");
+        producer.close();
+    }
+}

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/SubscriberImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/SubscriberImpl.java
@@ -1,0 +1,92 @@
+package com.wfa.crosstalk.impl.pubsub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wfa.crosstalk.core.pubsub.Subscriber;
+import com.wfa.crosstalk.util.MessageProcessor;
+import com.wfa.crosstalk.util.Subscription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+@Service
+public class SubscriberImpl implements Subscriber {
+
+    private static final Logger log = LoggerFactory.getLogger(SubscriberImpl.class);
+
+    private final KafkaConsumer<String, String> consumer;
+    private final ExecutorService executorService;
+    private final ConcurrentHashMap<String, MessageProcessor> topicToProcessor = new ConcurrentHashMap<>();
+
+    private volatile boolean running = true;
+    private boolean started = false;
+
+    public SubscriberImpl(@Value("${com.wfa.crosstalk.pubsub.bootstrapServers}") String bootstrapServers, @Value("${com.wfa.crosstalk.pubsub.groupId}") String groupId) {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+
+        log.info("Creating Kafka consumer with bootstrapServers: {}, groupId: {}", bootstrapServers, groupId);
+        this.consumer = new KafkaConsumer<>(properties);    // TODO: Investigate and fix
+        this.executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public <T> void subscribe(String topic, Class<T> targetType, Consumer<T> messageHandler) {
+        MessageProcessor processor = new Subscription<>(targetType, messageHandler);
+        topicToProcessor.put(topic, processor);
+        if (!started) {
+            started = true;
+            executorService.submit(this::pollLoop);
+        }
+    }
+
+    private void pollLoop() {
+        while (running) {
+            try {
+                consumer.subscribe(topicToProcessor.keySet());
+                var records = consumer.poll(Duration.ofMillis(100));
+                for (ConsumerRecord<String, String> record : records) {
+                    var processor = topicToProcessor.get(record.topic());
+                    if (processor != null) {
+                        processor.process(record.value());
+                    }
+                }
+            } catch (WakeupException e) {
+                if (!running) {
+                    break;
+                }
+            } catch (Exception e) {
+                log.error("Error in polling loop", e);
+            }
+        }
+        consumer.close();
+    }
+
+    private void stop() {
+        running = false;
+        consumer.wakeup();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        stop();
+        executorService.shutdown();
+    }
+}

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/SubscriberImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/SubscriberImpl.java
@@ -43,7 +43,7 @@ public class SubscriberImpl implements Subscriber {
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
 
         log.info("Creating Kafka consumer with bootstrapServers: {}, groupId: {}", bootstrapServers, groupId);
-        this.consumer = new KafkaConsumer<>(properties);    // TODO: Investigate and fix
+        this.consumer = new KafkaConsumer<>(properties);
         this.executorService = Executors.newSingleThreadExecutor();
     }
 

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/TopicManagerImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/TopicManagerImpl.java
@@ -27,7 +27,7 @@ public class TopicManagerImpl implements TopicManager {
 
     public TopicManagerImpl(@Value("${com.wfa.crosstalk.pubsub.bootstrapServers}") String bootstrapServers, @Value("${com.wfa.crosstalk.pubsub.adminTimeout:10}") int adminTimeout) {
         logger.info("Creating topic manager with bootstrapServers: {}", bootstrapServers);
-        this.adminClient = createAdminClient(bootstrapServers);     // TODO: Investigate and fix
+        this.adminClient = createAdminClient(bootstrapServers);
         this.adminTimeout = adminTimeout;
     }
 

--- a/src/main/java/com/wfa/crosstalk/impl/pubsub/TopicManagerImpl.java
+++ b/src/main/java/com/wfa/crosstalk/impl/pubsub/TopicManagerImpl.java
@@ -1,0 +1,82 @@
+package com.wfa.crosstalk.impl.pubsub;
+
+import com.wfa.crosstalk.core.pubsub.TopicManager;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TopicManagerImpl implements TopicManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(TopicManagerImpl.class);
+
+    private final AdminClient adminClient;
+    private final int adminTimeout;
+
+    public TopicManagerImpl(@Value("${com.wfa.crosstalk.pubsub.bootstrapServers}") String bootstrapServers, @Value("${com.wfa.crosstalk.pubsub.adminTimeout:10}") int adminTimeout) {
+        logger.info("Creating topic manager with bootstrapServers: {}", bootstrapServers);
+        this.adminClient = createAdminClient(bootstrapServers);     // TODO: Investigate and fix
+        this.adminTimeout = adminTimeout;
+    }
+
+    private AdminClient createAdminClient(String bootstrapServers) {
+        var properties = new java.util.Properties();
+        properties.put("bootstrap.servers", bootstrapServers);
+        return AdminClient.create(properties);
+    }
+
+    @Override
+    public void createTopic(String topicName, int partitions, short replicationFactor) {
+        NewTopic newTopic = new NewTopic(topicName, partitions, replicationFactor);
+        try {
+            adminClient.createTopics(List.of(newTopic)).all().get(adminTimeout, TimeUnit.SECONDS);
+            logger.info("Topic {} created successfully.", topicName);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof TopicExistsException) {
+                logger.info("Topic {} already exists.", topicName);
+            } else {
+                logger.error("Error creating topic {}: {}", topicName, e.getMessage(), e);
+            }
+        } catch (InterruptedException e) {
+            logger.error("Interrupted while creating topic {}: {}", topicName, e.getMessage(), e);
+            Thread.currentThread().interrupt();
+        } catch (java.util.concurrent.TimeoutException e) {
+            logger.error("Timeout while creating topic {}: {}", topicName, e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<String> listTopics() {
+        try {
+            ListTopicsResult topics = adminClient.listTopics();
+            return new ArrayList<>(topics.names().get(adminTimeout, TimeUnit.SECONDS));
+        } catch (ExecutionException | java.util.concurrent.TimeoutException e) {
+            logger.error("Error listing topics: {}", e.getMessage(), e);
+            return List.of();
+        } catch (InterruptedException e) {
+            logger.error("Interrupted while listing topics: {}", e.getMessage(), e);
+            Thread.currentThread().interrupt();
+            return List.of();
+        }
+    }
+
+    @PreDestroy
+    public void close() {
+        if (adminClient != null) {
+            adminClient.close();
+            logger.info("AdminClient closed.");
+        }
+    }
+}

--- a/src/main/java/com/wfa/crosstalk/util/MessageProcessor.java
+++ b/src/main/java/com/wfa/crosstalk/util/MessageProcessor.java
@@ -1,0 +1,5 @@
+package com.wfa.crosstalk.util;
+
+public interface MessageProcessor {
+    void process(String message);
+}

--- a/src/main/java/com/wfa/crosstalk/util/Subscription.java
+++ b/src/main/java/com/wfa/crosstalk/util/Subscription.java
@@ -1,0 +1,29 @@
+package com.wfa.crosstalk.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
+
+public class Subscription<T> implements MessageProcessor {
+    private final Class<T> targetType;
+    private final Consumer<T> messageHandler;
+    private static final Logger log = LoggerFactory.getLogger(Subscription.class);
+
+    public Subscription(Class<T> targetType, Consumer<T> messageHandler) {
+        this.targetType = targetType;
+        this.messageHandler = messageHandler;
+    }
+
+    @Override
+    public void process(String message) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            T obj = objectMapper.readValue(message, targetType);
+            messageHandler.accept(obj);
+        } catch (Exception e) {
+            log.error("Error processing message", e);
+        }
+    }
+}

--- a/src/main/resources/sample-application.properties
+++ b/src/main/resources/sample-application.properties
@@ -1,2 +1,2 @@
-com.wfa.crosstalk.pubsub.bootstrapServers="localhost:9092"
-com.wfa.crosstalk.pubsub.groupId="crosstalk-demo"
+com.wfa.crosstalk.pubsub.bootstrapServers=localhost:9092
+com.wfa.crosstalk.pubsub.groupId=crosstalk-demo

--- a/src/main/resources/sample-application.properties
+++ b/src/main/resources/sample-application.properties
@@ -1,0 +1,2 @@
+com.wfa.crosstalk.pubsub.bootstrapServers="localhost:9092"
+com.wfa.crosstalk.pubsub.groupId="crosstalk-demo"


### PR DESCRIPTION
This pull request introduces support for the framework's publish-subscribe (pub-sub) communication model by utilizing Apache Kafka. With this addition, projects that inherit this framework can easily incorporate pub-sub capabilities, enabling efficient message broadcasting and subscription management without dealing with low-level complexities.

TODO: investigate why currently breaking due to errors related to invalid 'bootstrap.servers'. Most probably a kafka setup issue but requires investigation.